### PR TITLE
Hotfix: Geolocation Desync & WriteNoteForm Adjustments

### DIFF
--- a/app/src/components/Editor/WriteNoteForm.tsx
+++ b/app/src/components/Editor/WriteNoteForm.tsx
@@ -181,7 +181,7 @@ const WriteNoteForm: React.FC<FormHandlerProps> = ({ updateViewState }) => {
   };
 
   const fetchLocationName = async (latitude: number, longitude: number) => {
-    const repsonse = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?latlng=${latitude},${longitude}&result_type=locality&key=${import.meta.env.VITE_GOOGLE_MAPS_API_KEY}`);
+    const repsonse = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?latlng=${latitude},${longitude}&result_type=locality&key=${import.meta.env.VITE_GCP_MAPS_API_KEY}`);
     const data = await repsonse.json();
     const formatted_address = data.plus_code.compound_code.split(' ').slice(1).join(' ');
     

--- a/app/src/components/Feed/FeedNoteItem/Location.tsx
+++ b/app/src/components/Feed/FeedNoteItem/Location.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from 'react';
-
 type LocationProps = {
   address: string | null;
 }
+
 const Location: React.FC<LocationProps> = ({ address }) => {
   if (address) {
     return (


### PR DESCRIPTION
- If Geolocation was denied in Browser, and allowed in settings, the error would freeze submission of a note. Now, we detect the desync and ask the user to fix it. Unfortunately, this does delete the note that they were originally working on.

- Removed CharacterLimit
- Removed Overflow
- Added Check for Empty Text