### PR TITLE
Native Config Changes & Sign In Changed to Popup

### DIFF
--- a/app/capacitor.config.ts
+++ b/app/capacitor.config.ts
@@ -1,10 +1,10 @@
 import { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
-  appId: 'com.gratitudenotes.app',
-  appName: 'gratitude-notes-core',
+  appId: 'com.dose.app',
+  appName: 'dose',
   webDir: 'dist',
-  bundledWebRuntime: false
+  bundledWebRuntime: false,
 };
 
 export default config;

--- a/app/src/components/Navbar/SignInButton.tsx
+++ b/app/src/components/Navbar/SignInButton.tsx
@@ -1,4 +1,4 @@
-import { getRedirectResult, GoogleAuthProvider, signInWithRedirect } from "@firebase/auth";
+import { GoogleAuthProvider, signInWithPopup } from "@firebase/auth";
 import { fb_auth } from "../../lib/Firebase";
 
 const SignInButton = () => {
@@ -6,8 +6,7 @@ const SignInButton = () => {
         const provider = new GoogleAuthProvider();
         provider.addScope('https://www.googleapis.com/auth/userinfo.email');
         
-        await signInWithRedirect(fb_auth, provider);
-        await getRedirectResult(fb_auth);
+        await signInWithPopup(fb_auth, provider);
     }
 
     return (


### PR DESCRIPTION
- Some browsers prevent third-party storage access preventing our login from functioning via redirect.